### PR TITLE
Fix TravisCI failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ rvm:
   - 2.6
 
 before_install:
-  - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
-  - rvm @global do gem uninstall bundler -a -x -I || true
-  - gem install bundler -v '~> 1.10'
+  - gem install bundler
 
 gemfile:
   - gemfiles/rails_4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.6
 
 before_install:
+  - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
   - gem install bundler -v '~> 1.10'
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ rvm:
   - 2.6
 
 before_install:
-  - gem install bundler
+  - rvm @global do gem uninstall bundler -a -x -I || true
+  - gem install bundler -v '~> 1.10'
 
 gemfile:
   - gemfiles/rails_4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
 
 before_install:
   - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
+  - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler -v '~> 1.10'
 
 gemfile:


### PR DESCRIPTION
Ruby 2.3 and Rails 4.2 build failed because of incorrect bundler version
in TravisCI. Bypass this one by deleting default bundler present in
TravisCI.
